### PR TITLE
Add tolerance parameter to recommendation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The simplest demo can be launched with:
 python ai2.py
 ```
 
-After starting the program select a reference video (e.g. `source.mp4`) when prompted. The webcam feed will be compared against the reference, recommendations will be displayed on the screen and voiced via `pyttsx3`.  Use the **Tolerance** slider in the window to adjust the acceptable angle deviation (default is 15 degrees).
+After starting the program select a reference video (e.g. `source.mp4`) when prompted. The webcam feed will be compared against the reference, recommendations will be displayed on the screen and voiced via `pyttsx3`.  Use the **Tolerance** slider in the window to adjust the value passed to `generate_recommendations`.  The slider starts at 15 degrees by default.
 
 Some scripts in the repository contain additional utilities for preprocessing data (`ai.py`, `main.py`, etc.). Feel free to explore them for experiments.
 
@@ -75,8 +75,9 @@ The script writes validation accuracy values to `val_accuracy.txt` and saves
 ## Exercise recommendations
 
 The helper function `generate_recommendations` in `format.py` analyzes several
-joint angles between the user's pose and a reference pose. It now covers elbows,
-knees, shoulders and hips, returning a textual hint whenever an angle differs by
-more than 10 degrees.
+joint angles between the user's pose and a reference pose. It covers elbows,
+knees, shoulders and hips.  Pass a ``tolerance`` value (in degrees) to control
+how much deviation is allowed before a textual hint is returned.  When no
+tolerance is supplied the default of 10 degrees is used.
 
 

--- a/ai2.py
+++ b/ai2.py
@@ -52,7 +52,7 @@ def speak_async(msg):
 
 def speak(user_pts, ref_pts):
     """Generate and voice hints using ``format.generate_recommendations``."""
-    hints = format.generate_recommendations(ref_pts, user_pts)
+    hints = format.generate_recommendations(ref_pts, user_pts, tolerance=ANGLE_TOLERANCE)
     global spoken_hints
     new_spoken = set()
     for msg in hints:

--- a/format.py
+++ b/format.py
@@ -71,8 +71,19 @@ def calculate_angle(a, b, c):
     return angle
 
 
-def generate_recommendations(ideal_pose, real_pose):
-    """Return textual feedback for each joint angle that differs noticeably."""
+def generate_recommendations(ideal_pose, real_pose, tolerance: float = 10):
+    """Return textual feedback for each joint angle that differs noticeably.
+
+    Parameters
+    ----------
+    ideal_pose : array-like
+        Reference landmark coordinates.
+    real_pose : array-like
+        User landmark coordinates.
+    tolerance : float, optional
+        Maximum allowed deviation in degrees before a recommendation is
+        generated. Defaults to ``10``.
+    """
 
     messages = {
         (11, 13, 15): "Выпрямьте левый локоть",
@@ -89,7 +100,7 @@ def generate_recommendations(ideal_pose, real_pose):
     for i, j, k in ANGLE_POINTS:
         ideal_angle = calculate_angle(ideal_pose[i], ideal_pose[j], ideal_pose[k])
         real_angle = calculate_angle(real_pose[i], real_pose[j], real_pose[k])
-        if abs(ideal_angle - real_angle) > 10:
+        if abs(ideal_angle - real_angle) > tolerance:
             msg = messages.get((i, j, k), f"Корректируйте угол {i}-{j}-{k}")
             recommendations.append(
                 f"{msg}. Эталонный: {ideal_angle:.2f}, ваш: {real_angle:.2f}"

--- a/pipeline.py
+++ b/pipeline.py
@@ -77,8 +77,20 @@ def classify_sequence(sequence, model):
         return int(out.argmax(dim=1).item())
 
 
-def run_pipeline(reference_video, target_video, model_path=None):
-    """Полный цикл обработки видео."""
+def run_pipeline(reference_video, target_video, model_path=None, tolerance=10):
+    """Полный цикл обработки видео.
+
+    Parameters
+    ----------
+    reference_video : str
+        Path to the reference video.
+    target_video : str
+        Path to the video to analyse.
+    model_path : str, optional
+        Path to a trained model.
+    tolerance : float, optional
+        Allowed deviation in degrees for ``generate_recommendations``.
+    """
     ref = normalize_skeleton(extract_skeletons(reference_video))
     seq = normalize_skeleton(extract_skeletons(target_video))
 
@@ -96,7 +108,7 @@ def run_pipeline(reference_video, target_video, model_path=None):
     error = evaluate_error(ref, seq)
     print(f"Average error: {error:.4f}")
 
-    recs = generate_recommendations(ref[-1], seq[-1])
+    recs = generate_recommendations(ref[-1], seq[-1], tolerance=tolerance)
     if recs:
         print("Recommendations:")
         for r in recs:
@@ -110,10 +122,11 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) < 3:
-        print("Usage: python pipeline.py <reference_video> <target_video> [model]")
+        print("Usage: python pipeline.py <reference_video> <target_video> [model] [tolerance]")
         sys.exit(1)
 
     ref_video = sys.argv[1]
     tar_video = sys.argv[2]
     mdl = sys.argv[3] if len(sys.argv) > 3 else None
-    run_pipeline(ref_video, tar_video, mdl)
+    tol = float(sys.argv[4]) if len(sys.argv) > 4 else 10
+    run_pipeline(ref_video, tar_video, mdl, tolerance=tol)

--- a/tests/test_angles.py
+++ b/tests/test_angles.py
@@ -174,7 +174,7 @@ def test_generate_recommendations_extended():
         i, j, k = triple
         real[k] = np.array([1, 0])  # distort one joint
 
-        recs = format.generate_recommendations(ideal, real)
+        recs = format.generate_recommendations(ideal, real, tolerance=10)
         # Expect at least one hint about the changed joint
         hint = messages[triple]
         assert any(hint in r for r in recs)
@@ -183,8 +183,8 @@ def test_generate_recommendations_extended():
 def test_speak_invokes_generate_recommendations(monkeypatch):
     called = {}
 
-    def fake_gen(ref, real):
-        called['args'] = (ref, real)
+    def fake_gen(ref, real, tolerance=None):
+        called['args'] = (ref, real, tolerance)
         return ['hint']
 
     monkeypatch.setattr(ai2, 'spoken_hints', set(), raising=False)
@@ -195,7 +195,7 @@ def test_speak_invokes_generate_recommendations(monkeypatch):
     ref = [[1, 1]] * 29
     hints = ai2.speak(user, ref)
 
-    assert called['args'] == (ref, user)
+    assert called['args'] == (ref, user, ai2.ANGLE_TOLERANCE)
     assert hints == ['hint']
     assert called.get('spoken') == ['hint']
 


### PR DESCRIPTION
## Summary
- support user-defined tolerance in `generate_recommendations`
- pass `ANGLE_TOLERANCE` from `ai2.speak`
- expose tolerance in `pipeline.run_pipeline`
- update README documentation
- fix unit tests for new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b19f92ec483299f14110765571c16