### PR TITLE
Add skeleton comparison plot to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ tolerance is supplied the default of 10 degrees is used.
 `pipeline.py` can compare two videos frame by frame using Dynamic Time Warping
 (DTW).  The script extracts the skeleton sequence from each video and prints a
 DTW similarity score.  Lower values mean the movements are closer together,
-with a perfect match resulting in `0`.
+with a perfect match resulting in `0`.  It also plots the joint angle
+trajectories of both skeletons so you can visually judge how similar the
+motions are.
 
 Run the pipeline from the command line:
 


### PR DESCRIPTION
## Summary
- visualize joint angles for two skeletons with `plot_angle_comparison`
- call the new plotting function from `run_pipeline`
- document the new visualization feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf05d917c8329b47cf19828766242